### PR TITLE
fix(spelling): correcting grammar

### DIFF
--- a/tests/e2e/assets/1.0.0-proj/src/app/app.component.spec.ts
+++ b/tests/e2e/assets/1.0.0-proj/src/app/app.component.spec.ts
@@ -17,7 +17,7 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   }));
 
-  it(`should have as title 'app works!'`, async(() => {
+  it(`should have a title 'app works!'`, async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('app works!');


### PR DESCRIPTION
I believe this should read "should have a title 'app works!'" not "should have as title 'app works!'". 